### PR TITLE
fix(ci,docs): update execution-specs artifact aggregation; fix selector

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,11 +59,11 @@ env:
   # Branch configuration - must match execution-specs allowlist
   # Format: branch_path|label
   BRANCH_CONFIG: |
-    experiments/publish-docs|Amsterdam
-    experiments/publish-docs-test|Amsterdam (Test)
+    forks/amsterdam|Amsterdam
+    devnets/bal/4|bal-devnet-4
 
   # Default branch within the product — /docs/<PRODUCT>/ redirects here
-  DEFAULT_BRANCH: experiments/publish-docs
+  DEFAULT_BRANCH: forks/amsterdam
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,12 @@
 #   - workflow_dispatch: Manual trigger for testing/recovery
 #
 # Site structure at steel.ethereum.foundation:
-#   /                              - Zensical site
-#   /docs/                         - Zensical landing page (docs/docs/index.md)
-#   /docs/default/                 - Permalink; redirects to current default branch
-#   /docs/<branch>/                - Branch-specific docs
-#   /docs/<branch>/specs/reference - Branch-specific spec
-#   /docs/versions.json            - Version manifest
+#   /                                         - Zensical site
+#   /docs/                                    - Zensical landing page (docs/docs/index.md)
+#   /docs/<product>/default/                  - Permalink; redirects to current default branch
+#   /docs/<product>/<branch>/                 - Branch-specific docs
+#   /docs/<product>/<branch>/specs/reference  - Branch-specific spec
+#   /docs/versions.json                       - Version manifest
 
 name: Build and Deploy
 
@@ -53,13 +53,16 @@ env:
   # Source repository for docs artifacts
   SOURCE_REPO: ethereum/execution-specs
 
+  # Product namespace — artifacts stage under site/docs/<PRODUCT>/<branch>/
+  PRODUCT: execution-specs
+
   # Branch configuration - must match execution-specs allowlist
   # Format: branch_path|label
   BRANCH_CONFIG: |
     experiments/publish-docs|Amsterdam
     experiments/publish-docs-test|Amsterdam (Test)
 
-  # Default branch — /docs/ redirects here
+  # Default branch within the product — /docs/<PRODUCT>/default/ redirects here
   DEFAULT_BRANCH: experiments/publish-docs
 
 jobs:
@@ -217,8 +220,8 @@ jobs:
               continue
             fi
 
-            mkdir -p "site/docs/$(dirname "$BRANCH")"
-            rsync -av "$SOURCE_DIR/" "site/docs/$BRANCH/"
+            mkdir -p "site/docs/$PRODUCT/$(dirname "$BRANCH")"
+            rsync -av "$SOURCE_DIR/" "site/docs/$PRODUCT/$BRANCH/"
             echo "Staged branch $BRANCH"
           done
 
@@ -229,7 +232,7 @@ jobs:
           HAS_DEFAULT="false"
 
           for BRANCH in $successful_branches; do
-            if [ -d "site/docs/$BRANCH" ]; then
+            if [ -d "site/docs/$PRODUCT/$BRANCH" ]; then
               if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
                 HAS_DEFAULT="true"
               fi
@@ -246,6 +249,7 @@ jobs:
         if: github.event.inputs.skip_docs != 'true'
         run: |
           uv run scripts/assemble-docs.py site/docs \
+            --product "$PRODUCT" \
             --branch-config "$BRANCH_CONFIG" \
             --default-branch "$DEFAULT_BRANCH"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -278,8 +278,8 @@ jobs:
 
             while IFS='|' read -r path label; do
               if [ -z "$path" ]; then continue; fi
-              if [ -d "site/docs/$path" ]; then
-                SIZE=$(du -sh "site/docs/$path" | cut -f1)
+              if [ -d "site/docs/$PRODUCT/$path" ]; then
+                SIZE=$(du -sh "site/docs/$PRODUCT/$path" | cut -f1)
                 DEFAULT_MARKER=""
                 if [ "$path" = "$DEFAULT_BRANCH" ]; then
                   DEFAULT_MARKER=" (default)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,23 +151,31 @@ jobs:
             echo ""
             echo "=== Processing branch: $BRANCH ==="
 
-            # Find the latest successful workflow run for this branch
-            RUN_ID=$(gh run list \
-              --repo "$SOURCE_REPO" \
-              --workflow "docs-build.yaml" \
-              --branch "$BRANCH" \
-              --status success \
-              --limit 1 \
-              --json databaseId \
-              --jq '.[0].databaseId' 2>/dev/null || echo "")
+            # Find the latest successful workflow run for this branch.
+            # Filter by event type: only push and workflow_dispatch produce
+            # artifacts (PR runs succeed but upload nothing).
+            RUN_ID=""
+            for EVENT_TYPE in push workflow_dispatch; do
+              RUN_ID=$(gh run list \
+                --repo "$SOURCE_REPO" \
+                --workflow "docs-build.yaml" \
+                --branch "$BRANCH" \
+                --status success \
+                --event "$EVENT_TYPE" \
+                --limit 1 \
+                --json databaseId \
+                --jq '.[0].databaseId' 2>/dev/null || echo "")
+              if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+                echo "Found run ID: $RUN_ID (event: $EVENT_TYPE)"
+                break
+              fi
+            done
 
             if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
               echo "WARNING: No successful run found for branch $BRANCH"
               FAILED_BRANCHES="$FAILED_BRANCHES $BRANCH"
               continue
             fi
-
-            echo "Found run ID: $RUN_ID"
 
             if gh run download "$RUN_ID" \
               --repo "$SOURCE_REPO" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,14 +9,12 @@
 #   - workflow_dispatch: Manual trigger for testing/recovery
 #
 # Site structure at steel.ethereum.foundation:
-#   /                             - Zensical site
-#   /docs/                        - Forwards to /docs/default/
-#   /docs/spec/                   - Forwards to /docs/default/spec/
-#   /docs/default/                - Permalink; redirects to current default branch
-#   /docs/default/spec/           - Permalink; redirects to current default branch spec
-#   /docs/<branch>/               - Branch-specific docs
+#   /                              - Zensical site
+#   /docs/                         - Zensical landing page (docs/docs/index.md)
+#   /docs/default/                 - Permalink; redirects to current default branch
+#   /docs/<branch>/                - Branch-specific docs
 #   /docs/<branch>/specs/reference - Branch-specific spec
-#   /docs/versions.json           - Version manifest
+#   /docs/versions.json            - Version manifest
 
 name: Build and Deploy
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -258,11 +258,7 @@ jobs:
       - name: Generate versions.json
         if: github.event.inputs.skip_docs != 'true'
         run: |
-          cat > site/docs/versions.json <<EOF
-          {
-            "default": "${DEFAULT_BRANCH}",
-            "versions": [
-          EOF
+          echo "[" > site/docs/versions.json
 
           FIRST=true
           while IFS='|' read -r path label; do
@@ -281,19 +277,10 @@ jobs:
               echo "," >> site/docs/versions.json
             fi
 
-            cat >> site/docs/versions.json <<ENTRY
-              {
-                "version": "$path",
-                "title": "$label",
-                "aliases": $ALIASES
-              }
-          ENTRY
+            echo "{\"version\": \"$path\", \"title\": \"$label\", \"aliases\": $ALIASES}" >> site/docs/versions.json
           done <<< "$BRANCH_CONFIG"
 
-          cat >> site/docs/versions.json <<'EOF'
-            ]
-          }
-          EOF
+          echo "]" >> site/docs/versions.json
 
           echo "Generated versions.json:"
           cat site/docs/versions.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,14 @@
 #   - workflow_dispatch: Manual trigger for testing/recovery
 #
 # Site structure at steel.ethereum.foundation:
-#   /                   - Zensical site
-#   /docs/              - Redirect to default branch
-#   /docs/spec/         - Redirect to default branch spec
-#   /docs/<branch>/     - Branch-specific docs
-#   /docs/<branch>/spec - Branch-specific spec
-#   /docs/versions.json - Version manifest
+#   /                             - Zensical site
+#   /docs/                        - Forwards to /docs/default/
+#   /docs/spec/                   - Forwards to /docs/default/spec/
+#   /docs/default/                - Permalink; redirects to current default branch
+#   /docs/default/spec/           - Permalink; redirects to current default branch spec
+#   /docs/<branch>/               - Branch-specific docs
+#   /docs/<branch>/specs/reference - Branch-specific spec
+#   /docs/versions.json           - Version manifest
 
 name: Build and Deploy
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,8 @@
 #
 # Site structure at steel.ethereum.foundation:
 #   /                   - Zensical site
-#   /docs/              - Default branch docs (mirrored)
-#   /docs/spec/         - Default branch spec (mirrored)
+#   /docs/              - Redirect to default branch
+#   /docs/spec/         - Redirect to default branch spec
 #   /docs/<branch>/     - Branch-specific docs
 #   /docs/<branch>/spec - Branch-specific spec
 #   /docs/versions.json - Version manifest
@@ -64,7 +64,7 @@ env:
     experiments/publish-docs|Amsterdam
     experiments/publish-docs-test|Amsterdam (Test)
 
-  # Default branch to mirror to root of /docs/
+  # Default branch — /docs/ redirects here
   DEFAULT_BRANCH: experiments/publish-docs
 
 jobs:
@@ -247,85 +247,12 @@ jobs:
             echo "WARNING: Default branch $DEFAULT_BRANCH is not available"
           fi
 
-      - name: Mirror default branch to root of /docs/
-        if: github.event.inputs.skip_docs != 'true' && steps.validate.outputs.has_default == 'true'
-        run: |
-          echo "Mirroring $DEFAULT_BRANCH to root of /docs/"
-
-          rsync -av \
-            --exclude='spec/' \
-            --exclude='mainnet/' \
-            --exclude='forks/' \
-            --exclude='devnets/' \
-            --exclude='eips/' \
-            "site/docs/$DEFAULT_BRANCH/" site/docs/
-
-          mkdir -p site/docs/spec
-          rsync -av "site/docs/$DEFAULT_BRANCH/spec/" site/docs/spec/
-
-      - name: Generate versions.json
+      - name: Assemble docs (version selector, versions.json, redirects)
         if: github.event.inputs.skip_docs != 'true'
         run: |
-          echo "[" > site/docs/versions.json
-
-          FIRST=true
-          while IFS='|' read -r path label; do
-            if [ -z "$path" ] || [ ! -d "site/docs/$path" ]; then
-              continue
-            fi
-
-            ALIASES="[]"
-            if [ "$path" = "$DEFAULT_BRANCH" ]; then
-              ALIASES='["latest"]'
-            fi
-
-            if [ "$FIRST" = "true" ]; then
-              FIRST=false
-            else
-              echo "," >> site/docs/versions.json
-            fi
-
-            echo "{\"version\": \"$path\", \"title\": \"$label\", \"aliases\": $ALIASES}" >> site/docs/versions.json
-          done <<< "$BRANCH_CONFIG"
-
-          echo "]" >> site/docs/versions.json
-
-          echo "Generated versions.json:"
-          cat site/docs/versions.json
-
-      - name: Copy versions.json to intermediate directories
-        if: github.event.inputs.skip_docs != 'true'
-        run: |
-          # MkDocs Material's version selector looks for ../versions.json relative
-          # to the current version directory. For multi-depth branch paths like
-          # forks/amsterdam or devnets/amsterdam/2, we need to copy versions.json
-          # to intermediate directories so the selector can find it.
-          #
-          # e.g., /docs/forks/amsterdam/ looks for /docs/forks/versions.json
-          #       /docs/devnets/amsterdam/2/ looks for /docs/devnets/amsterdam/versions.json
-
-          while IFS='|' read -r path _; do
-            if [ -z "$path" ] || [ ! -d "site/docs/$path" ]; then
-              continue
-            fi
-
-            # Get parent directory of the branch path
-            PARENT_DIR=$(dirname "$path")
-            if [ "$PARENT_DIR" != "." ]; then
-              # Copy versions.json to parent directory
-              mkdir -p "site/docs/$PARENT_DIR"
-              cp site/docs/versions.json "site/docs/$PARENT_DIR/versions.json"
-              echo "Copied versions.json to site/docs/$PARENT_DIR/"
-
-              # For deeper paths (e.g., devnets/amsterdam/2), also copy to grandparent
-              GRANDPARENT_DIR=$(dirname "$PARENT_DIR")
-              if [ "$GRANDPARENT_DIR" != "." ]; then
-                mkdir -p "site/docs/$GRANDPARENT_DIR"
-                cp site/docs/versions.json "site/docs/$GRANDPARENT_DIR/versions.json"
-                echo "Copied versions.json to site/docs/$GRANDPARENT_DIR/"
-              fi
-            fi
-          done <<< "$BRANCH_CONFIG"
+          uv run scripts/assemble-docs.py site/docs \
+            --branch-config "$BRANCH_CONFIG" \
+            --default-branch "$DEFAULT_BRANCH"
 
       # --- End Docs Aggregation ---
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,18 +52,8 @@ permissions:
 env:
   # Source repository for docs artifacts
   SOURCE_REPO: ethereum/execution-specs
-
-  # Product namespace — artifacts stage under site/docs/<PRODUCT>/<branch>/
-  PRODUCT: execution-specs
-
-  # Branch configuration - must match execution-specs allowlist
-  # Format: branch_path|label
-  BRANCH_CONFIG: |
-    forks/amsterdam|Amsterdam
-    devnets/bal/4|bal-devnet-4
-
-  # Default branch within the product — /docs/<PRODUCT>/ redirects here
-  DEFAULT_BRANCH: forks/amsterdam
+  # PRODUCT, BRANCH_CONFIG and DEFAULT_BRANCH are loaded from docs-config.yml
+  # by the "Load docs config" step below.
 
 jobs:
   deploy:
@@ -88,6 +78,22 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Load docs config
+        run: |
+          PRODUCT=$(yq '.product' docs-config.yml)
+          DEFAULT_BRANCH=$(yq '.default_branch' docs-config.yml)
+          BRANCH_CONFIG=$(yq '.branches[] | .path + "|" + .label' docs-config.yml)
+          echo "PRODUCT=$PRODUCT" >> "$GITHUB_ENV"
+          echo "DEFAULT_BRANCH=$DEFAULT_BRANCH" >> "$GITHUB_ENV"
+          {
+            echo "BRANCH_CONFIG<<EOF"
+            echo "$BRANCH_CONFIG"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+          echo "Loaded config: product=$PRODUCT, default_branch=$DEFAULT_BRANCH"
+          echo "Branches:"
+          echo "$BRANCH_CONFIG"
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@
 # Site structure at steel.ethereum.foundation:
 #   /                                         - Zensical site
 #   /docs/                                    - Zensical landing page (docs/docs/index.md)
-#   /docs/<product>/default/                  - Permalink; redirects to current default branch
+#   /docs/<product>/                          - Permalink; redirects to current default branch
 #   /docs/<product>/<branch>/                 - Branch-specific docs
 #   /docs/<product>/<branch>/specs/reference  - Branch-specific spec
 #   /docs/versions.json                       - Version manifest
@@ -62,7 +62,7 @@ env:
     experiments/publish-docs|Amsterdam
     experiments/publish-docs-test|Amsterdam (Test)
 
-  # Default branch within the product — /docs/<PRODUCT>/default/ redirects here
+  # Default branch within the product — /docs/<PRODUCT>/ redirects here
   DEFAULT_BRANCH: experiments/publish-docs
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@
 # Triggers:
 #   - Push to main: Rebuilds when site content changes
 #   - repository_dispatch: Triggered by execution-specs when docs are updated
-#   - schedule: Daily rebuild to catch any missed updates
 #   - workflow_dispatch: Manual trigger for testing/recovery
 #
 # Site structure at steel.ethereum.foundation:
@@ -40,10 +39,6 @@ on:
         required: false
         type: boolean
         default: false
-
-  # Scheduled fallback for recovery from transient failures
-  schedule:
-    - cron: "0 4 * * *" # Daily at 4 AM UTC
 
 concurrency:
   group: deploy

--- a/docs-config.yml
+++ b/docs-config.yml
@@ -1,0 +1,13 @@
+# Single source of truth for docs aggregation.
+# Consumed by .github/workflows/deploy.yml (via yq) and
+# scripts/local-assemble.py (via pyyaml).
+# BRANCH paths must also appear in the execution-specs docs-producer allowlist.
+
+product: execution-specs
+default_branch: forks/amsterdam
+
+branches:
+  - path: forks/amsterdam
+    label: Amsterdam
+  - path: devnets/bal/4
+    label: bal-devnet-4

--- a/docs-config.yml
+++ b/docs-config.yml
@@ -11,3 +11,5 @@ branches:
     label: Amsterdam
   - path: devnets/bal/4
     label: bal-devnet-4
+  - path: experiments/publish-docs
+    label: Amsterdam

--- a/docs-config.yml
+++ b/docs-config.yml
@@ -11,5 +11,5 @@ branches:
     label: Amsterdam
   - path: devnets/bal/4
     label: bal-devnet-4
-  - path: experiments/publish-docs
-    label: Amsterdam
+  - path: mainnet
+    label: Mainnet (BPO2)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,4 +4,5 @@
 
 The [Ethereum execution-layer specification](https://github.com/ethereum/execution-specs).
 
-- [Amsterdam](/docs/execution-specs/experiments/publish-docs/)
+- [Amsterdam](/docs/execution-specs/forks/amsterdam/).
+- [`bal-devnet-4`](/docs/execution-specs/devnets/bal/4/).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,4 +4,4 @@
 
 The [Ethereum execution-layer specification](https://github.com/ethereum/execution-specs).
 
-- [Amsterdam](/docs/forks/amsterdam/)
+- [Amsterdam](/docs/execution-specs/forks/amsterdam/)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,4 +4,4 @@
 
 The [Ethereum execution-layer specification](https://github.com/ethereum/execution-specs).
 
-- [Amsterdam](/docs/execution-specs/forks/amsterdam/)
+- [Amsterdam](/docs/execution-specs/experiments/publish-docs/)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,0 +1,7 @@
+# Documentation
+
+## execution-specs
+
+The [Ethereum execution-layer specification](https://github.com/ethereum/execution-specs).
+
+- [Amsterdam](/docs/forks/amsterdam/)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,8 +1,9 @@
 # Documentation
 
-## execution-specs
+## ethereum/execution-specs
 
-The [Ethereum execution-layer specification](https://github.com/ethereum/execution-specs).
+HTML documentation is available for the following [ethereum/execution-specs](https://github.com/ethereum/execution-specs) branches.
 
-- [Amsterdam](/docs/execution-specs/forks/amsterdam/).
-- [`bal-devnet-4`](/docs/execution-specs/devnets/bal/4/).
+| execution-specs branch | HTML docs |
+| --- | --- |
+| [experiments/publish-docs](https://github.com/ethereum/execution-specs/tree/experiments/publish-docs) | [Amsterdam](/docs/execution-specs/experiments/publish-docs/) |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -6,4 +6,4 @@ HTML documentation is available for the following [ethereum/execution-specs](htt
 
 | execution-specs branch | HTML docs |
 | --- | --- |
-| [experiments/publish-docs](https://github.com/ethereum/execution-specs/tree/experiments/publish-docs) | [Amsterdam](/docs/execution-specs/experiments/publish-docs/) |
+| [forks/amsterdam](https://github.com/ethereum/execution-specs/tree/forks/amsterdam) | [Amsterdam](/docs/execution-specs/forks/amsterdam/) |

--- a/scripts/assemble-docs.py
+++ b/scripts/assemble-docs.py
@@ -6,11 +6,10 @@ three operations in order:
 
 1. Injects the custom version selector <script> tag into all HTML files.
 2. Generates versions.json (flat array with url fields).
-3. Generates redirect index.html files:
-   - /docs/default/ and /docs/default/spec/ are stable permalinks that track
-     the current default branch, so external links survive the rollover from
-     e.g. forks/amsterdam to forks/bogota.
-   - /docs/ and /docs/spec/ forward to those permalinks for backward compat.
+3. Generates /docs/default/ — a stable permalink that tracks the current
+   default branch, so external links survive the rollover from e.g.
+   forks/amsterdam to forks/bogota.
+   /docs/ itself is the Zensical-built landing page and is not overwritten.
 
 Usage (from repo root):
     uv run scripts/assemble-docs.py site/docs \\
@@ -110,30 +109,19 @@ def generate_versions_json(
 
 
 def generate_redirects(docs_dir: Path, default_branch: str) -> None:
-    """Generate permalink redirects under docs/default/ and forwarders at docs root.
+    """Generate the /docs/default/ permalink redirect.
 
-    /docs/default/ and /docs/default/spec/ are the stable permalinks — they
-    track the current default branch and survive its rollover. /docs/ and
-    /docs/spec/ forward through the permalinks so the old URLs keep working.
+    /docs/default/ tracks the current default branch so external links survive
+    the rollover from e.g. forks/amsterdam to forks/bogota.
+
+    /docs/ itself is the Zensical-built landing page (docs/docs/index.md) and
+    is intentionally not written here so we don't overwrite it.
     """
-    branch_url = f"/docs/{default_branch}/"
-    branch_spec_url = f"/docs/{default_branch}/specs/reference/"
-    targets = [
-        # Permalinks: /docs/default/... -> current default branch.
-        (docs_dir / "default" / "index.html", branch_url, default_branch),
-        (
-            docs_dir / "default" / "spec" / "index.html",
-            branch_spec_url,
-            f"{default_branch}/specs/reference",
-        ),
-        # Forwarders: /docs/ and /docs/spec/ -> /docs/default/...
-        (docs_dir / "index.html", "/docs/default/", "default"),
-        (docs_dir / "spec" / "index.html", "/docs/default/spec/", "default/spec"),
-    ]
-    for dest, url, label in targets:
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(REDIRECT_TEMPLATE.format(url=url, label=label))
-        print(f"Generated redirect: {dest.relative_to(docs_dir)} -> {url}")
+    dest = docs_dir / "default" / "index.html"
+    url = f"/docs/{default_branch}/"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(REDIRECT_TEMPLATE.format(url=url, label=default_branch))
+    print(f"Generated redirect: {dest.relative_to(docs_dir)} -> {url}")
 
 
 def main() -> None:

--- a/scripts/assemble-docs.py
+++ b/scripts/assemble-docs.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env -S uv run --script
+"""Post-staging assembly for aggregated docs.
+
+Runs after branch artifacts have been staged into a docs directory. Performs
+three operations in order:
+
+1. Injects the custom version selector <script> tag into all HTML files.
+2. Generates versions.json (flat array with url fields).
+3. Generates redirect index.html files at the docs root and spec/.
+
+Usage (from repo root):
+    uv run scripts/assemble-docs.py site/docs \\
+        --branch-config "forks/amsterdam|Amsterdam" \\
+        --default-branch forks/amsterdam
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_TAG = '<script src="/docs/assets/version-selector.js"></script>'
+
+REDIRECT_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url={url}">
+  <link rel="canonical" href="{url}">
+  <title>Redirecting&hellip;</title>
+</head>
+<body>
+  <p>Redirecting to <a href="{url}">{label}</a>.</p>
+</body>
+</html>
+"""
+
+
+def parse_branch_config(raw: str) -> list[tuple[str, str]]:
+    """Parse 'path|label' lines into (path, label) tuples."""
+    entries = []
+    for line in raw.strip().splitlines():
+        line = line.strip()
+        if not line or "|" not in line:
+            continue
+        path, label = line.split("|", 1)
+        entries.append((path.strip(), label.strip()))
+    return entries
+
+
+def inject_version_selector(docs_dir: Path) -> int:
+    """Copy version-selector.js and inject a <script> tag into all HTML files."""
+    scripts_dir = Path(__file__).resolve().parent
+    src = scripts_dir / "version-selector.js"
+    if not src.exists():
+        print(f"ERROR: {src} not found", file=sys.stderr)
+        return 0
+
+    dest = docs_dir / "assets" / "version-selector.js"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(src.read_text())
+    print(f"Copied {src.name} to {dest.relative_to(docs_dir)}")
+
+    count = 0
+    for html_file in docs_dir.rglob("*.html"):
+        content = html_file.read_text()
+        if "</body>" in content and SCRIPT_TAG not in content:
+            html_file.write_text(content.replace("</body>", f"{SCRIPT_TAG}</body>"))
+            count += 1
+
+    print(f"Injected version selector into {count} HTML files.")
+    return count
+
+
+def generate_versions_json(
+    docs_dir: Path,
+    branches: list[tuple[str, str]],
+    default_branch: str,
+) -> Path:
+    """Generate versions.json as a flat array with url fields."""
+    versions = []
+    for path, label in branches:
+        if not (docs_dir / path).is_dir():
+            print(f"  Skipping {path} (directory not found).")
+            continue
+        aliases = ["latest"] if path == default_branch else []
+        versions.append(
+            {
+                "version": path,
+                "title": label,
+                "aliases": aliases,
+                "url": f"/docs/{path}/",
+            }
+        )
+
+    out = docs_dir / "versions.json"
+    out.write_text(json.dumps(versions, indent=2) + "\n")
+    print(f"Generated {out.name} with {len(versions)} version(s):")
+    for v in versions:
+        tag = " (default)" if v["version"] == default_branch else ""
+        print(f"  {v['version']}: {v['title']}{tag}")
+    return out
+
+
+def generate_redirects(docs_dir: Path, default_branch: str) -> None:
+    """Generate redirect index.html at docs root and docs/spec/."""
+    targets = [
+        (docs_dir / "index.html", f"/docs/{default_branch}/", default_branch),
+        (
+            docs_dir / "spec" / "index.html",
+            f"/docs/{default_branch}/spec/",
+            f"{default_branch}/spec",
+        ),
+    ]
+    for dest, url, label in targets:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(REDIRECT_TEMPLATE.format(url=url, label=label))
+        print(f"Generated redirect: {dest.relative_to(docs_dir)} -> {url}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("docs_dir", type=Path, help="Path to the staged docs directory (e.g. site/docs).")
+    parser.add_argument("--branch-config", required=True, help="Branch config lines (path|label), newline-separated.")
+    parser.add_argument("--default-branch", required=True, help="Default branch path (e.g. forks/amsterdam).")
+    args = parser.parse_args()
+
+    docs_dir = args.docs_dir.resolve()
+    if not docs_dir.is_dir():
+        print(f"ERROR: {docs_dir} is not a directory.", file=sys.stderr)
+        sys.exit(1)
+
+    branches = parse_branch_config(args.branch_config)
+    if not branches:
+        print("ERROR: No branches parsed from --branch-config.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"=== Assembling docs in {docs_dir} ===\n")
+
+    # 1. Inject version selector (must run before redirects are written).
+    inject_version_selector(docs_dir)
+    print()
+
+    # 2. Generate versions.json.
+    generate_versions_json(docs_dir, branches, args.default_branch)
+    print()
+
+    # 3. Generate redirects (written last so they don't get the script tag).
+    generate_redirects(docs_dir, args.default_branch)
+    print()
+
+    print("Assembly complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/assemble-docs.py
+++ b/scripts/assemble-docs.py
@@ -6,8 +6,8 @@ Runs after branch artifacts have been staged into a docs directory under
 
 1. Injects the custom version selector <script> tag into all HTML files.
 2. Generates versions.json (flat array with url fields).
-3. Generates /docs/<product>/default/ — a stable permalink that tracks the
-   current default branch, so external links survive the rollover from e.g.
+3. Generates /docs/<product>/ — a stable permalink that tracks the current
+   default branch, so external links survive the rollover from e.g.
    forks/amsterdam to forks/bogota.
    /docs/ itself is the Zensical-built landing page and is not overwritten.
 
@@ -117,15 +117,16 @@ def generate_versions_json(
 
 
 def generate_redirects(docs_dir: Path, product: str, default_branch: str) -> None:
-    """Generate the /docs/<product>/default/ permalink redirect.
+    """Generate the /docs/<product>/ permalink redirect.
 
-    Tracks the product's current default branch so external links survive the
-    rollover from e.g. forks/amsterdam to forks/bogota.
+    /docs/<product>/ itself tracks the product's current default branch so
+    external links survive the rollover from e.g. forks/amsterdam to
+    forks/bogota.
 
     /docs/ itself is the Zensical-built landing page (docs/docs/index.md) and
     is intentionally not written here so we don't overwrite it.
     """
-    dest = docs_dir / product / "default" / "index.html"
+    dest = docs_dir / product / "index.html"
     url = f"/docs/{product}/{default_branch}/"
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(REDIRECT_TEMPLATE.format(url=url, label=f"{product}/{default_branch}"))

--- a/scripts/assemble-docs.py
+++ b/scripts/assemble-docs.py
@@ -6,7 +6,11 @@ three operations in order:
 
 1. Injects the custom version selector <script> tag into all HTML files.
 2. Generates versions.json (flat array with url fields).
-3. Generates redirect index.html files at the docs root and spec/.
+3. Generates redirect index.html files:
+   - /docs/default/ and /docs/default/spec/ are stable permalinks that track
+     the current default branch, so external links survive the rollover from
+     e.g. forks/amsterdam to forks/bogota.
+   - /docs/ and /docs/spec/ forward to those permalinks for backward compat.
 
 Usage (from repo root):
     uv run scripts/assemble-docs.py site/docs \\
@@ -106,14 +110,25 @@ def generate_versions_json(
 
 
 def generate_redirects(docs_dir: Path, default_branch: str) -> None:
-    """Generate redirect index.html at docs root and docs/spec/."""
+    """Generate permalink redirects under docs/default/ and forwarders at docs root.
+
+    /docs/default/ and /docs/default/spec/ are the stable permalinks — they
+    track the current default branch and survive its rollover. /docs/ and
+    /docs/spec/ forward through the permalinks so the old URLs keep working.
+    """
+    branch_url = f"/docs/{default_branch}/"
+    branch_spec_url = f"/docs/{default_branch}/specs/reference/"
     targets = [
-        (docs_dir / "index.html", f"/docs/{default_branch}/", default_branch),
+        # Permalinks: /docs/default/... -> current default branch.
+        (docs_dir / "default" / "index.html", branch_url, default_branch),
         (
-            docs_dir / "spec" / "index.html",
-            f"/docs/{default_branch}/spec/",
-            f"{default_branch}/spec",
+            docs_dir / "default" / "spec" / "index.html",
+            branch_spec_url,
+            f"{default_branch}/specs/reference",
         ),
+        # Forwarders: /docs/ and /docs/spec/ -> /docs/default/...
+        (docs_dir / "index.html", "/docs/default/", "default"),
+        (docs_dir / "spec" / "index.html", "/docs/default/spec/", "default/spec"),
     ]
     for dest, url, label in targets:
         dest.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/assemble-docs.py
+++ b/scripts/assemble-docs.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env -S uv run --script
 """Post-staging assembly for aggregated docs.
 
-Runs after branch artifacts have been staged into a docs directory. Performs
-three operations in order:
+Runs after branch artifacts have been staged into a docs directory under
+<product>/<branch>/. Performs three operations in order:
 
 1. Injects the custom version selector <script> tag into all HTML files.
 2. Generates versions.json (flat array with url fields).
-3. Generates /docs/default/ — a stable permalink that tracks the current
-   default branch, so external links survive the rollover from e.g.
+3. Generates /docs/<product>/default/ — a stable permalink that tracks the
+   current default branch, so external links survive the rollover from e.g.
    forks/amsterdam to forks/bogota.
    /docs/ itself is the Zensical-built landing page and is not overwritten.
 
 Usage (from repo root):
     uv run scripts/assemble-docs.py site/docs \\
+        --product execution-specs \\
         --branch-config "forks/amsterdam|Amsterdam" \\
         --default-branch forks/amsterdam
 """
@@ -80,55 +81,63 @@ def inject_version_selector(docs_dir: Path) -> int:
 
 def generate_versions_json(
     docs_dir: Path,
+    product: str,
     branches: list[tuple[str, str]],
     default_branch: str,
 ) -> Path:
-    """Generate versions.json as a flat array with url fields."""
+    """Generate versions.json as a flat array with url fields.
+
+    Each entry's `version` field is the URL-path segment after /docs/
+    (i.e. "<product>/<branch>"), so version-selector.js can match it with a
+    simple startsWith against location.pathname.
+    """
     versions = []
     for path, label in branches:
-        if not (docs_dir / path).is_dir():
-            print(f"  Skipping {path} (directory not found).")
+        if not (docs_dir / product / path).is_dir():
+            print(f"  Skipping {product}/{path} (directory not found).")
             continue
         aliases = ["latest"] if path == default_branch else []
         versions.append(
             {
-                "version": path,
+                "version": f"{product}/{path}",
                 "title": label,
                 "aliases": aliases,
-                "url": f"/docs/{path}/",
+                "url": f"/docs/{product}/{path}/",
             }
         )
 
     out = docs_dir / "versions.json"
     out.write_text(json.dumps(versions, indent=2) + "\n")
     print(f"Generated {out.name} with {len(versions)} version(s):")
+    default_version = f"{product}/{default_branch}"
     for v in versions:
-        tag = " (default)" if v["version"] == default_branch else ""
+        tag = " (default)" if v["version"] == default_version else ""
         print(f"  {v['version']}: {v['title']}{tag}")
     return out
 
 
-def generate_redirects(docs_dir: Path, default_branch: str) -> None:
-    """Generate the /docs/default/ permalink redirect.
+def generate_redirects(docs_dir: Path, product: str, default_branch: str) -> None:
+    """Generate the /docs/<product>/default/ permalink redirect.
 
-    /docs/default/ tracks the current default branch so external links survive
-    the rollover from e.g. forks/amsterdam to forks/bogota.
+    Tracks the product's current default branch so external links survive the
+    rollover from e.g. forks/amsterdam to forks/bogota.
 
     /docs/ itself is the Zensical-built landing page (docs/docs/index.md) and
     is intentionally not written here so we don't overwrite it.
     """
-    dest = docs_dir / "default" / "index.html"
-    url = f"/docs/{default_branch}/"
+    dest = docs_dir / product / "default" / "index.html"
+    url = f"/docs/{product}/{default_branch}/"
     dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_text(REDIRECT_TEMPLATE.format(url=url, label=default_branch))
+    dest.write_text(REDIRECT_TEMPLATE.format(url=url, label=f"{product}/{default_branch}"))
     print(f"Generated redirect: {dest.relative_to(docs_dir)} -> {url}")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("docs_dir", type=Path, help="Path to the staged docs directory (e.g. site/docs).")
+    parser.add_argument("--product", required=True, help="Product namespace (e.g. execution-specs).")
     parser.add_argument("--branch-config", required=True, help="Branch config lines (path|label), newline-separated.")
-    parser.add_argument("--default-branch", required=True, help="Default branch path (e.g. forks/amsterdam).")
+    parser.add_argument("--default-branch", required=True, help="Default branch path within the product (e.g. forks/amsterdam).")
     args = parser.parse_args()
 
     docs_dir = args.docs_dir.resolve()
@@ -141,18 +150,18 @@ def main() -> None:
         print("ERROR: No branches parsed from --branch-config.", file=sys.stderr)
         sys.exit(1)
 
-    print(f"=== Assembling docs in {docs_dir} ===\n")
+    print(f"=== Assembling docs in {docs_dir} (product: {args.product}) ===\n")
 
     # 1. Inject version selector (must run before redirects are written).
     inject_version_selector(docs_dir)
     print()
 
     # 2. Generate versions.json.
-    generate_versions_json(docs_dir, branches, args.default_branch)
+    generate_versions_json(docs_dir, args.product, branches, args.default_branch)
     print()
 
     # 3. Generate redirects (written last so they don't get the script tag).
-    generate_redirects(docs_dir, args.default_branch)
+    generate_redirects(docs_dir, args.product, args.default_branch)
     print()
 
     print("Assembly complete.")

--- a/scripts/assemble-docs.py
+++ b/scripts/assemble-docs.py
@@ -126,6 +126,16 @@ def generate_redirects(docs_dir: Path, product: str, default_branch: str) -> Non
     /docs/ itself is the Zensical-built landing page (docs/docs/index.md) and
     is intentionally not written here so we don't overwrite it.
     """
+    target_dir = docs_dir / product / default_branch
+    if not target_dir.is_dir():
+        # Skip the redirect when the default branch failed to stage; pointing
+        # /docs/<product>/ at a non-existent path is worse than no permalink.
+        print(
+            f"Skipping redirect: default branch {product}/{default_branch} not staged.",
+            file=sys.stderr,
+        )
+        return
+
     dest = docs_dir / product / "index.html"
     url = f"/docs/{product}/{default_branch}/"
     dest.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/assemble-docs.py
+++ b/scripts/assemble-docs.py
@@ -55,8 +55,8 @@ def parse_branch_config(raw: str) -> list[tuple[str, str]]:
     return entries
 
 
-def inject_version_selector(docs_dir: Path) -> int:
-    """Copy version-selector.js and inject a <script> tag into all HTML files."""
+def inject_version_selector(docs_dir: Path, product: str) -> int:
+    """Copy version-selector.js and inject a <script> tag into product HTML files"""
     scripts_dir = Path(__file__).resolve().parent
     src = scripts_dir / "version-selector.js"
     if not src.exists():
@@ -69,7 +69,7 @@ def inject_version_selector(docs_dir: Path) -> int:
     print(f"Copied {src.name} to {dest.relative_to(docs_dir)}")
 
     count = 0
-    for html_file in docs_dir.rglob("*.html"):
+    for html_file in (docs_dir / product).rglob("*.html"):
         content = html_file.read_text()
         if "</body>" in content and SCRIPT_TAG not in content:
             html_file.write_text(content.replace("</body>", f"{SCRIPT_TAG}</body>"))
@@ -154,7 +154,7 @@ def main() -> None:
     print(f"=== Assembling docs in {docs_dir} (product: {args.product}) ===\n")
 
     # 1. Inject version selector (must run before redirects are written).
-    inject_version_selector(docs_dir)
+    inject_version_selector(docs_dir, args.product)
     print()
 
     # 2. Generate versions.json.

--- a/scripts/local-assemble.py
+++ b/scripts/local-assemble.py
@@ -22,8 +22,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-# Mirrors the BRANCH_CONFIG in deploy.yml. Only branches with local artifacts
-# will be included in versions.json (the rest are skipped gracefully).
+# Mirrors the BRANCH_CONFIG and PRODUCT in deploy.yml. Only branches with local
+# artifacts will be included in versions.json (the rest are skipped gracefully).
+PRODUCT = "execution-specs"
+
 BRANCH_CONFIG = """\
 mainnet|Mainnet
 forks/amsterdam|Amsterdam
@@ -47,8 +49,8 @@ def build_zensical(site_dir: Path) -> None:
     print(f"Built to {site_dir}/\n")
 
 
-def stage_local_artifacts(docs_dir: Path) -> list[str]:
-    """Copy local artifacts into the docs staging directory.
+def stage_local_artifacts(docs_dir: Path, product: str) -> list[str]:
+    """Copy local artifacts into the docs staging directory under <product>/.
 
     Returns the list of branch paths that were staged.
     """
@@ -76,9 +78,9 @@ def stage_local_artifacts(docs_dir: Path) -> list[str]:
 
         # Derive the branch path from the directory structure.
         branch_path = str(branch_dir.relative_to(artifact))
-        dest = docs_dir / branch_path
+        dest = docs_dir / product / branch_path
 
-        print(f"  {artifact.name} -> docs/{branch_path}/")
+        print(f"  {artifact.name} -> docs/{product}/{branch_path}/")
         if dest.exists():
             shutil.rmtree(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)
@@ -112,6 +114,8 @@ def run_assemble(docs_dir: Path) -> None:
             "run",
             str(script),
             str(docs_dir),
+            "--product",
+            PRODUCT,
             "--branch-config",
             BRANCH_CONFIG,
             "--default-branch",
@@ -127,9 +131,10 @@ def serve(site_dir: Path, port: int) -> None:
     """Start a local HTTP server."""
     print(f"Serving {site_dir}/ at http://localhost:{port}")
     print("URLs to test:")
-    print(f"  http://localhost:{port}/docs/              (redirect)")
-    print(f"  http://localhost:{port}/docs/versions.json (versions)")
-    print(f"  http://localhost:{port}/docs/{DEFAULT_BRANCH}/  (docs + selector)")
+    print(f"  http://localhost:{port}/docs/                        (landing page)")
+    print(f"  http://localhost:{port}/docs/versions.json           (versions)")
+    print(f"  http://localhost:{port}/docs/{PRODUCT}/default/      (permalink)")
+    print(f"  http://localhost:{port}/docs/{PRODUCT}/{DEFAULT_BRANCH}/  (docs + selector)")
     print()
 
     handler = http.server.SimpleHTTPRequestHandler
@@ -162,7 +167,7 @@ def main() -> None:
 
     # 2. Stage local artifacts.
     docs_dir.mkdir(parents=True, exist_ok=True)
-    staged = stage_local_artifacts(docs_dir)
+    staged = stage_local_artifacts(docs_dir, PRODUCT)
     if not staged:
         print("WARNING: No artifacts staged. The docs section will be empty.")
 

--- a/scripts/local-assemble.py
+++ b/scripts/local-assemble.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env -S uv run --script
+#
+# /// script
+# dependencies = [
+#     "pyyaml==6.0.3",
+# ]
+# ///
 """Assemble the site locally for testing.
 
 Builds the Zensical landing page, stages local doc artifacts, and runs the
@@ -20,18 +26,18 @@ import subprocess
 import sys
 from pathlib import Path
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PATH = REPO_ROOT / "docs-config.yml"
 
-# Mirrors the BRANCH_CONFIG and PRODUCT in deploy.yml. Only branches with local
-# artifacts will be included in versions.json (the rest are skipped gracefully).
-PRODUCT = "execution-specs"
-
-BRANCH_CONFIG = """\
-forks/amsterdam|Amsterdam
-devnets/bal/4|bal-devnet-4
-"""
-
-DEFAULT_BRANCH = "forks/amsterdam"
+# Loaded from docs-config.yml — the single source of truth shared with
+# .github/workflows/deploy.yml. Only branches with local artifacts will be
+# included in versions.json (the rest are skipped gracefully).
+_config = yaml.safe_load(CONFIG_PATH.read_text())
+PRODUCT = _config["product"]
+DEFAULT_BRANCH = _config["default_branch"]
+BRANCH_CONFIG = "".join(f"{b['path']}|{b['label']}\n" for b in _config["branches"])
 
 
 def build_zensical(site_dir: Path) -> None:

--- a/scripts/local-assemble.py
+++ b/scripts/local-assemble.py
@@ -27,15 +27,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 PRODUCT = "execution-specs"
 
 BRANCH_CONFIG = """\
-mainnet|Mainnet
 forks/amsterdam|Amsterdam
-devnets/amsterdam/2|Amsterdam Devnet 2
-forks/amsterdocs|Test Branch
-experiments/publish-docs|Publish Docs
-experiments/publish-docs-test|Publish Docs (Test)
+devnets/bal/4|bal-devnet-4
 """
 
-DEFAULT_BRANCH = "experiments/publish-docs"
+DEFAULT_BRANCH = "forks/amsterdam"
 
 
 def build_zensical(site_dir: Path) -> None:

--- a/scripts/local-assemble.py
+++ b/scripts/local-assemble.py
@@ -29,9 +29,11 @@ mainnet|Mainnet
 forks/amsterdam|Amsterdam
 devnets/amsterdam/2|Amsterdam Devnet 2
 forks/amsterdocs|Test Branch
+experiments/publish-docs|Publish Docs
+experiments/publish-docs-test|Publish Docs (Test)
 """
 
-DEFAULT_BRANCH = "forks/amsterdam"
+DEFAULT_BRANCH = "experiments/publish-docs"
 
 
 def build_zensical(site_dir: Path) -> None:

--- a/scripts/local-assemble.py
+++ b/scripts/local-assemble.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env -S uv run --script
+"""Assemble the site locally for testing.
+
+Builds the Zensical landing page, stages local doc artifacts, and runs the
+assemble-docs pipeline. Optionally starts an HTTP server to view the result.
+
+Usage:
+    uv run scripts/local-assemble.py            # build only
+    uv run scripts/local-assemble.py --serve     # build and serve on port 8000
+    uv run scripts/local-assemble.py --serve -p 9000  # custom port
+    uv run scripts/local-assemble.py --skip-zensical   # skip the zensical build
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.server
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Mirrors the BRANCH_CONFIG in deploy.yml. Only branches with local artifacts
+# will be included in versions.json (the rest are skipped gracefully).
+BRANCH_CONFIG = """\
+mainnet|Mainnet
+forks/amsterdam|Amsterdam
+devnets/amsterdam/2|Amsterdam Devnet 2
+forks/amsterdocs|Test Branch
+"""
+
+DEFAULT_BRANCH = "forks/amsterdam"
+
+
+def build_zensical(site_dir: Path) -> None:
+    """Build the Zensical landing site."""
+    print("=== Building Zensical site ===", flush=True)
+    subprocess.run(
+        ["uv", "run", "zensical", "build", "--clean"],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    print(f"Built to {site_dir}/\n")
+
+
+def stage_local_artifacts(docs_dir: Path) -> list[str]:
+    """Copy local artifacts into the docs staging directory.
+
+    Returns the list of branch paths that were staged.
+    """
+    print("=== Staging local artifacts ===")
+    artifacts_dir = REPO_ROOT / "artifacts"
+    staged = []
+
+    if not artifacts_dir.is_dir():
+        print(f"No artifacts directory at {artifacts_dir}.")
+        return staged
+
+    # Each artifact directory is named branch_safe (e.g. forks-amsterdam) and
+    # contains the branch content at <branch_path>/ inside it.
+    for artifact in sorted(artifacts_dir.iterdir()):
+        if not artifact.is_dir() or artifact.name.startswith("."):
+            continue
+
+        # Find the branch content directory inside the artifact.
+        # The artifact has the structure: artifact/<branch_path>/...
+        # e.g. forks-amsterdam/forks/amsterdam/index.html
+        branch_dir = _find_branch_content(artifact)
+        if not branch_dir:
+            print(f"  Skipping {artifact.name} (no content found).")
+            continue
+
+        # Derive the branch path from the directory structure.
+        branch_path = str(branch_dir.relative_to(artifact))
+        dest = docs_dir / branch_path
+
+        print(f"  {artifact.name} -> docs/{branch_path}/")
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(branch_dir, dest)
+        staged.append(branch_path)
+
+    print(f"Staged {len(staged)} branch(es).\n")
+    return staged
+
+
+def _find_branch_content(artifact_dir: Path) -> Path | None:
+    """Find the branch root directory inside an artifact.
+
+    The artifact contains the branch content nested at its branch path, e.g.
+    artifacts/forks-amsterdam/forks/amsterdam/index.html. We find the
+    shallowest directory containing index.html (closest to the artifact root).
+    """
+    candidates = list(artifact_dir.rglob("index.html"))
+    if not candidates:
+        return None
+    return min(candidates, key=lambda p: len(p.parts)).parent
+
+
+def run_assemble(docs_dir: Path) -> None:
+    """Run assemble-docs.py on the staged docs directory."""
+    print("=== Running assemble-docs ===\n", flush=True)
+    script = REPO_ROOT / "scripts" / "assemble-docs.py"
+    subprocess.run(
+        [
+            "uv",
+            "run",
+            str(script),
+            str(docs_dir),
+            "--branch-config",
+            BRANCH_CONFIG,
+            "--default-branch",
+            DEFAULT_BRANCH,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    print()
+
+
+def serve(site_dir: Path, port: int) -> None:
+    """Start a local HTTP server."""
+    print(f"Serving {site_dir}/ at http://localhost:{port}")
+    print("URLs to test:")
+    print(f"  http://localhost:{port}/docs/              (redirect)")
+    print(f"  http://localhost:{port}/docs/versions.json (versions)")
+    print(f"  http://localhost:{port}/docs/{DEFAULT_BRANCH}/  (docs + selector)")
+    print()
+
+    handler = http.server.SimpleHTTPRequestHandler
+    server = http.server.HTTPServer(("", port), handler)
+    import os
+
+    os.chdir(site_dir)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--serve", action="store_true", help="Start HTTP server after building.")
+    parser.add_argument("-p", "--port", type=int, default=8000, help="Port for HTTP server (default: 8000).")
+    parser.add_argument("--skip-zensical", action="store_true", help="Skip the Zensical site build.")
+    args = parser.parse_args()
+
+    site_dir = REPO_ROOT / "site"
+    docs_dir = site_dir / "docs"
+
+    # 1. Build the Zensical landing site.
+    if not args.skip_zensical:
+        build_zensical(site_dir)
+    else:
+        print("=== Skipping Zensical build ===\n")
+        site_dir.mkdir(parents=True, exist_ok=True)
+
+    # 2. Stage local artifacts.
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    staged = stage_local_artifacts(docs_dir)
+    if not staged:
+        print("WARNING: No artifacts staged. The docs section will be empty.")
+
+    # 3. Run assembly (inject selector, gen versions.json, gen redirects).
+    run_assemble(docs_dir)
+
+    # 4. Add .nojekyll.
+    (site_dir / ".nojekyll").touch()
+
+    print(f"Site assembled at {site_dir}/")
+    total_size = sum(f.stat().st_size for f in site_dir.rglob("*") if f.is_file())
+    print(f"Total size: {total_size / (1024 * 1024):.1f} MB\n")
+
+    if args.serve:
+        serve(site_dir, args.port)
+    else:
+        print("To serve locally:")
+        print(f"  uv run scripts/local-assemble.py --serve")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/local-assemble.py
+++ b/scripts/local-assemble.py
@@ -133,7 +133,7 @@ def serve(site_dir: Path, port: int) -> None:
     print("URLs to test:")
     print(f"  http://localhost:{port}/docs/                        (landing page)")
     print(f"  http://localhost:{port}/docs/versions.json           (versions)")
-    print(f"  http://localhost:{port}/docs/{PRODUCT}/default/      (permalink)")
+    print(f"  http://localhost:{port}/docs/{PRODUCT}/              (permalink)")
     print(f"  http://localhost:{port}/docs/{PRODUCT}/{DEFAULT_BRANCH}/  (docs + selector)")
     print()
 

--- a/scripts/version-selector.js
+++ b/scripts/version-selector.js
@@ -1,0 +1,106 @@
+// Custom version selector for multi-depth branch paths.
+//
+// Material's built-in selector (provider: mike) breaks for our URL structure
+// because it extracts only the last path segment and uses relative navigation.
+// This script uses absolute paths throughout and is injected during deploy.
+(function () {
+  "use strict";
+
+  var DOCS_PREFIX = "/docs/";
+  var VERSIONS_URL = DOCS_PREFIX + "versions.json";
+
+  // Find the current version by matching location.pathname against known paths.
+  // Longest match wins (so "devnets/amsterdam/2" beats "devnets/amsterdam").
+  function findCurrentVersion(versions) {
+    var path = location.pathname;
+    var best = null;
+    for (var i = 0; i < versions.length; i++) {
+      var prefix = DOCS_PREFIX + versions[i].version + "/";
+      if (path.startsWith(prefix)) {
+        if (!best || versions[i].version.length > best.version.length) {
+          best = versions[i];
+        }
+      }
+    }
+    return best;
+  }
+
+  function buildSelector(versions, current) {
+    // Use Material's own CSS classes so styling is native.
+    var container = document.createElement("div");
+    container.className = "md-version";
+
+    var btn = document.createElement("button");
+    btn.className = "md-version__current";
+    btn.setAttribute("aria-label", "Select version");
+    btn.textContent = current ? current.title : "Select version";
+
+    if (current && current.aliases && current.aliases.length > 0) {
+      var aliasSpan = document.createElement("span");
+      aliasSpan.className = "md-version__alias";
+      aliasSpan.textContent = current.aliases[0];
+      btn.appendChild(aliasSpan);
+    }
+
+    var list = document.createElement("ul");
+    list.className = "md-version__list";
+
+    for (var i = 0; i < versions.length; i++) {
+      var v = versions[i];
+      var li = document.createElement("li");
+      li.className = "md-version__item";
+
+      var a = document.createElement("a");
+      a.className = "md-version__link";
+      a.href = v.url || (DOCS_PREFIX + v.version + "/");
+      a.textContent = v.title;
+
+      if (v.aliases && v.aliases.length > 0) {
+        var alias = document.createElement("span");
+        alias.className = "md-version__alias";
+        alias.textContent = v.aliases[0];
+        a.appendChild(alias);
+      }
+
+      li.appendChild(a);
+      list.appendChild(li);
+    }
+
+    container.appendChild(btn);
+    container.appendChild(list);
+    return container;
+  }
+
+  function inject(versions, current) {
+    var target = document.querySelector(".md-header__topic");
+    if (!target) return;
+
+    // Remove Material's built-in (broken) selector if it rendered.
+    var existing = target.querySelector(".md-version");
+    if (existing) existing.remove();
+
+    target.appendChild(buildSelector(versions, current));
+  }
+
+  function init() {
+    if (!location.pathname.startsWith(DOCS_PREFIX)) return;
+
+    fetch(VERSIONS_URL)
+      .then(function (r) {
+        if (!r.ok) throw new Error(r.status);
+        return r.json();
+      })
+      .then(function (versions) {
+        inject(versions, findCurrentVersion(versions));
+      })
+      .catch(function () {
+        // Silent -- same behaviour as Material's built-in.
+      });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/scripts/version-selector.js
+++ b/scripts/version-selector.js
@@ -91,7 +91,9 @@
         return r.json();
       })
       .then(function (versions) {
-        inject(versions, findCurrentVersion(versions));
+        var current = findCurrentVersion(versions);
+        if (!current) return;
+        inject(versions, current);
       })
       .catch(function () {
         // Silent -- same behaviour as Material's built-in.

--- a/zensical.toml
+++ b/zensical.toml
@@ -49,6 +49,7 @@ nav = [
     { "About" = "about.md" },
     { "Responsibilities" = "responsibilities.md" },
     { "Team" = "team.md" },
+    { "Docs" = "docs/index.md" },
     { "Blog" = [
         "blog/2025-11-27_osaka_mainnet_tests.md",
         "blog/2025-11-04_weld_final.md",


### PR DESCRIPTION
Redesigns the docs aggregation pipeline.

- Replace the bash/rsync assembly with `scripts/assemble-docs.py` (inject version selector, generate `versions.json`, write redirects).
- Add a custom `scripts/version-selector.js` that handles multi-depth branch paths (Material's built-in selector breaks on `devnets/amsterdam/2`).
- Namespace docs URLs under `/docs/<product>/<branch>/`, with the product root itself (`/docs/execution-specs/`) as a stable permalink redirecting to the current default branch. Done pre-launch so no external links break.
- Add a Zensical landing page at `/docs/` (`docs/docs/index.md`) listing available products.
- Filter artifact discovery by event type (`push`, `workflow_dispatch`) since PR runs succeed but produce no artifacts.
- Drop the daily deploy cron. Push-to-main and `repository_dispatch` from execution-specs already cover the real triggers.
- Centralize `product`, `default_branch`, and `branches[]` in `docs-config.yml`. CI reads it via `yq`; `scripts/local-assemble.py` reads it via `pyyaml==6.0.3`.
- Switch the branch config to `forks/amsterdam` (default) and `devnets/bal/4`.

## Files

- `docs-config.yml` (new). Single source of truth for the docs pipeline.
- `scripts/assemble-docs.py` (new). Post-staging assembly.
- `scripts/local-assemble.py` (new). Full pipeline driver for local development.
- `scripts/version-selector.js` (new). Client-side version picker.
- `docs/docs/index.md` (new). `/docs/` landing page.
- `.github/workflows/deploy.yml`. Loads `docs-config.yml`, calls the new scripts, drops cron.
- `zensical.toml`. Adds the Docs nav entry.
