### PR TITLE
fix: suppress Material's built-in version selector reliably

### DIFF
--- a/scripts/version-selector.js
+++ b/scripts/version-selector.js
@@ -9,6 +9,25 @@
   var DOCS_PREFIX = "/docs/";
   var VERSIONS_URL = DOCS_PREFIX + "versions.json";
 
+  // Marks the selector this script builds, so Material's own (broken) built-in
+  // selector can be told apart from ours and suppressed.
+  var MARKER = "data-steel-version";
+
+  // Hide any version selector in the header that isn't the one we inject.
+  // Material renders its mike-based selector client-side, and the timing
+  // relative to our async versions.json fetch is not deterministic: on a
+  // cache-warm navigation the fetch can resolve before Material injects,
+  // so a one-shot remove() in inject() misses it and both selectors show.
+  // A CSS rule applies to late-injected nodes too, so it wins the race.
+  function installSuppressor() {
+    if (document.getElementById("steel-version-suppressor")) return;
+    var style = document.createElement("style");
+    style.id = "steel-version-suppressor";
+    style.textContent =
+      ".md-header__topic .md-version:not([" + MARKER + "]){display:none!important}";
+    (document.head || document.documentElement).appendChild(style);
+  }
+
   // Find the current version by matching location.pathname against known paths.
   // Longest match wins (so "devnets/amsterdam/2" beats "devnets/amsterdam").
   function findCurrentVersion(versions) {
@@ -29,6 +48,7 @@
     // Use Material's own CSS classes so styling is native.
     var container = document.createElement("div");
     container.className = "md-version";
+    container.setAttribute(MARKER, "");
 
     var btn = document.createElement("button");
     btn.className = "md-version__current";
@@ -75,15 +95,21 @@
     var target = document.querySelector(".md-header__topic");
     if (!target) return;
 
-    // Remove Material's built-in (broken) selector if it rendered.
-    var existing = target.querySelector(".md-version");
-    if (existing) existing.remove();
+    // Remove Material's built-in (broken) selector(s) and any stale copy of
+    // ours. The CSS suppressor handles selectors Material injects later; this
+    // cleans up whatever is already present so the DOM stays tidy.
+    var stale = target.querySelectorAll(".md-version");
+    for (var i = 0; i < stale.length; i++) stale[i].remove();
 
     target.appendChild(buildSelector(versions, current));
   }
 
   function init() {
     if (!location.pathname.startsWith(DOCS_PREFIX)) return;
+
+    // Suppress Material's built-in selector up front, before the async fetch,
+    // so it can never flash in or linger if our fetch is slow.
+    installSuppressor();
 
     fetch(VERSIONS_URL)
       .then(function (r) {


### PR DESCRIPTION
The custom version selector removed Material's built-in mike selector once, synchronously, inside the versions.json fetch callback. When Material injected its selector after that callback ran (e.g. a cache-warm navigation back to the default branch, where the fetch resolves before Material renders), the removal missed it and both selectors showed.

Add a CSS rule that hides any header .md-version without our marker attribute. CSS applies to late-injected nodes too, so suppression no longer depends on timing. Install it up front in init(), and have inject() clear all pre-existing selectors rather than just the first.