### PR TITLE
fix(blog): show author byline as 'Leo Lara'

### DIFF
--- a/docs/blog/2026-06-11_specs-as-models.md
+++ b/docs/blog/2026-06-11_specs-as-models.md
@@ -6,7 +6,7 @@ description: "Reading the executable consensus specs as a formal model to system
 ---
 
 <div class="blog-metadata" markdown>
-:material-account: [Leo](../team.md#leo-lara) · :material-calendar: June 11, 2026 · :material-clock-outline: 35 min read
+:material-account: [Leo Lara](../team.md#leo-lara) · :material-calendar: June 11, 2026 · :material-clock-outline: 35 min read
 </div>
 
 *Thanks to [@brechy](https://github.com/brechy) and [@danceratopz](https://github.com/danceratopz) for their review and help.*


### PR DESCRIPTION
The merged ['Specs as Models' post](https://steel.ethereum.foundation/blog/2026-06-11_specs-as-models/) (#60) displayed its author as **Leo** instead of **Leo Lara**.

The frontmatter `author:` was already `Leo Lara`; the visible byline just used a shortened link text:

```diff
-:material-account: [Leo](../team.md#leo-lara) · …
+:material-account: [Leo Lara](../team.md#leo-lara) · …
```

The link target (`team.md#leo-lara`) is unchanged. Verified the built page now renders `<a href=".../team/#leo-lara">Leo Lara</a>`, and `zensical build` passes.